### PR TITLE
Add test case (and fix bug) for broken Set() behavior

### DIFF
--- a/record/type.go
+++ b/record/type.go
@@ -45,9 +45,17 @@ func (r Record) Set(nameParts []string, newValue interface{}) bool {
 		for _, namePart := range nameParts[1 : len(nameParts)-1] {
 			switch valTyped := val.(type) {
 			case map[string]interface{}:
-				val = valTyped[namePart]
+				val, ok = valTyped[namePart]
+				if !ok {
+					val = make(map[string]interface{})
+					valTyped[namePart] = val
+				}
 			case Record:
-				val = valTyped[namePart]
+				val, ok = valTyped[namePart]
+				if !ok {
+					val = make(map[string]interface{})
+					valTyped[namePart] = val
+				}
 			default:
 				return false
 			}

--- a/record/type_test.go
+++ b/record/type_test.go
@@ -148,6 +148,12 @@ func TestSet(t *testing.T) {
 					v: map[string]interface{}{},
 					e: true,
 				},
+				// set a map in a new keyspace
+				{
+					k: []string{"new", "top", "thing", "for", "stuff"},
+					v: 1,
+					e: true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Set() should create intermediate layers if they don't exist