### PR TITLE
Change stream transformation

### DIFF
--- a/query/result_stream.go
+++ b/query/result_stream.go
@@ -15,7 +15,7 @@ import (
 
 // Function to transform a given record
 // argument *must* be a pointer, otherwise you are passed a copy which you cannot replace directly
-type ResultStreamItemTransformation func(*record.Record) error
+type ResultStreamItemTransformation func(record.Record) (record.Record, error)
 
 // Encapsulate a streaming result from the datastore
 type ResultStream struct {
@@ -76,8 +76,10 @@ func (r *ResultStream) Recv() (record.Record, error) {
 	r.started = true
 	// Apply Transformations
 	for _, t := range r.transformations {
-		if err := t(&resultRecord); err != nil {
+		if transformedRecord, err := t(resultRecord); err != nil {
 			return resultRecord, err
+		} else if transformedRecord != nil {
+			resultRecord = transformedRecord
 		}
 	}
 	return resultRecord, nil

--- a/query/result_stream_bench_test.go
+++ b/query/result_stream_bench_test.go
@@ -28,9 +28,9 @@ func BenchmarkResultStream(b *testing.B) {
 func BenchmarkResultStreamTransformation(b *testing.B) {
 	val := record.Record{"a": 1}
 
-	tF := func(r *record.Record) error {
-		(*r)["t"] = "transformed"
-		return nil
+	tF := func(r record.Record) (record.Record, error) {
+		r["t"] = "transformed"
+		return r, nil
 	}
 
 	var err error

--- a/query/result_stream_test.go
+++ b/query/result_stream_test.go
@@ -13,7 +13,7 @@ import (
 func resultStreamGenerator(val interface{}, count int) *ResultStream {
 	ctx := context.Background()
 
-	resultsChan := make(chan stream.Result, 1)
+	resultsChan := make(chan stream.Result, 100)
 	errorChan := make(chan error, 1)
 
 	serverStream := local.NewServerStream(ctx, resultsChan, errorChan)

--- a/query/result_stream_test.go
+++ b/query/result_stream_test.go
@@ -49,10 +49,10 @@ func TestBasic(t *testing.T) {
 
 func TestBasicTransformation(t *testing.T) {
 	transformed := false
-	tF := func(r *record.Record) error {
-		(*r)["t"] = "transformed"
+	tF := func(r record.Record) (record.Record, error) {
+		r["t"] = "transformed"
 		transformed = true
-		return nil
+		return r, nil
 	}
 
 	val := record.Record{"a": 1}

--- a/routernode/node.go
+++ b/routernode/node.go
@@ -931,9 +931,8 @@ func (s *RouterNode) HandleStreamQuery(ctx context.Context, q *query.Query) *que
 		projectionFields := record.ProjectionFields(q.Args.Fields)
 
 		// Add projection transformation to the stream
-		err := result.AddTransformation(func(r *record.Record) error {
-			*r = (*r).Project(projectionFields)
-			return nil
+		err := result.AddTransformation(func(r record.Record) (record.Record, error) {
+			return r.Project(projectionFields), nil
 		})
 		if err != nil {
 			panic("unable to add transformation")

--- a/storagenode/datasource/pgstore/storage.go
+++ b/storagenode/datasource/pgstore/storage.go
@@ -844,9 +844,8 @@ func (s *Storage) FilterStream(ctx context.Context, args query.QueryArgs) *query
 	result.Stream = streamChan
 
 	// Add transformation to normalize the various JSON fields
-	result.AddTransformation(func(r *record.Record) error {
-		*r = s.normalizeRecord(collection, *r)
-		return nil
+	result.AddTransformation(func(r record.Record) (record.Record, error) {
+		return s.normalizeRecord(collection, r), nil
 	})
 
 	return result


### PR DESCRIPTION
Passing by pointer did make the function signature smaller, but apparently that caused a bunch of allocations. This switches that internal interface to avoid the allocations.