### PR TITLE
Use concrete types for stream, this allows these to be stack allocated

### DIFF
--- a/query/result_stream_bench_test.go
+++ b/query/result_stream_bench_test.go
@@ -61,7 +61,7 @@ func BenchmarkMergeResultStreamsUnique(b *testing.B) {
 	resultStreams := make([][]*ResultStream, b.N)
 
 	for x := 0; x < b.N; x++ {
-		resultsChan := make(chan stream.Result, 1)
+		resultsChan := make(chan record.Record, 1)
 		errorChan := make(chan error, 1)
 		serverStreams[x] = local.NewServerStream(ctx, resultsChan, errorChan)
 		clientStreams[x] = local.NewClientStream(ctx, resultsChan, errorChan)
@@ -102,7 +102,7 @@ func BenchmarkMergeResultStreams(b *testing.B) {
 	resultStreams := make([][]*ResultStream, b.N)
 
 	for x := 0; x < b.N; x++ {
-		resultsChan := make(chan stream.Result, 1)
+		resultsChan := make(chan record.Record, 1)
 		errorChan := make(chan error, 1)
 		serverStreams[x] = local.NewServerStream(ctx, resultsChan, errorChan)
 		clientStreams[x] = local.NewClientStream(ctx, resultsChan, errorChan)

--- a/query/result_stream_test.go
+++ b/query/result_stream_test.go
@@ -6,14 +6,12 @@ import (
 	"testing"
 
 	"github.com/jacksontj/dataman/record"
-	"github.com/jacksontj/dataman/stream"
 	"github.com/jacksontj/dataman/stream/local"
 )
 
-func resultStreamGenerator(val interface{}, count int) *ResultStream {
+func resultStreamGenerator(val record.Record, count int) *ResultStream {
 	ctx := context.Background()
-
-	resultsChan := make(chan stream.Result, 100)
+	resultsChan := make(chan record.Record, 1)
 	errorChan := make(chan error, 1)
 
 	serverStream := local.NewServerStream(ctx, resultsChan, errorChan)

--- a/routernode/httpapi.go
+++ b/routernode/httpapi.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jacksontj/dataman/httputil"
 	"github.com/jacksontj/dataman/metrics/promhandler"
 	"github.com/jacksontj/dataman/query"
-	"github.com/jacksontj/dataman/record"
 	"github.com/jacksontj/dataman/stream/httpjson"
 )
 
@@ -135,7 +134,7 @@ func (h *HTTPApi) rawQueryHandler(w http.ResponseWriter, r *http.Request, ps htt
 						serverStream.SendError(err)
 						return
 					} else {
-						serverStream.SendResult(result.(record.Record))
+						serverStream.SendResult(result)
 					}
 				}
 			}

--- a/routernode/node.go
+++ b/routernode/node.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jacksontj/dataman/routernode/client_manager"
 	"github.com/jacksontj/dataman/routernode/metadata"
 	"github.com/jacksontj/dataman/routernode/sharding"
-	"github.com/jacksontj/dataman/stream"
 	"github.com/jacksontj/dataman/stream/local"
 
 	storagenodemetadata "github.com/jacksontj/dataman/storagenode/metadata"
@@ -981,7 +980,7 @@ func (s *RouterNode) HandleStreamQuery(ctx context.Context, q *query.Query) *que
 
 	// Consolidate vshardResults to result
 
-	resultsChan := make(chan stream.Result, 1)
+	resultsChan := make(chan record.Record, 1)
 	errorChan := make(chan error, 1)
 
 	serverStream := local.NewServerStream(ctx, resultsChan, errorChan)

--- a/storagenode/datasource/pgstore/util.go
+++ b/storagenode/datasource/pgstore/util.go
@@ -81,7 +81,7 @@ func DoStreamQuery(ctx context.Context, db *sql.DB, query string, colAddrs []Col
 		return nil, fmt.Errorf("Error running query: Err=%v query=%s ", err, query)
 	}
 
-	resultsChan := make(chan stream.Result, 100)
+	resultsChan := make(chan record.Record, 100)
 	errorChan := make(chan error, 1)
 
 	serverStream := local.NewServerStream(ctx, resultsChan, errorChan)

--- a/stream/httpjson/client.go
+++ b/stream/httpjson/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/jacksontj/dataman/record"
 	"github.com/jacksontj/dataman/stream"
 )
 
@@ -69,7 +70,7 @@ func (s *ClientStream) handleStream() {
 
 }
 
-func (s *ClientStream) Recv() (stream.Result, error) {
+func (s *ClientStream) Recv() (record.Record, error) {
 	for {
 		// If we need a new chunk, get it
 		if s.currentChunk == nil || (len(s.currentChunk.Results) <= s.offset) {

--- a/stream/interface.go
+++ b/stream/interface.go
@@ -1,14 +1,16 @@
 package stream
 
+import "github.com/jacksontj/dataman/record"
+
 type ClientStream interface {
-	Recv() (Result, error)
+	Recv() (record.Record, error)
 	// Close completes receiving of items
 	Close() error
 }
 
 type ServerStream interface {
 	// Methods to send items
-	SendResult(Result) error
+	SendResult(record.Record) error
 	SendError(error) error
 	// Close completes sending of items-- no more items can be sent after Close() is called
 	Close() error

--- a/stream/local/all_test.go
+++ b/stream/local/all_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jacksontj/dataman/record"
 	"github.com/jacksontj/dataman/stream"
 )
 
@@ -11,7 +12,7 @@ import (
 func TestLocalStreams(t *testing.T) {
 	f := func(ctx context.Context) (stream.ServerStream, stream.ClientStream) {
 
-		resultsChan := make(chan stream.Result, 1)
+		resultsChan := make(chan record.Record, 1)
 		errorChan := make(chan error, 1)
 
 		server := NewServerStream(ctx, resultsChan, errorChan)

--- a/stream/local/client.go
+++ b/stream/local/client.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"io"
 
+	"github.com/jacksontj/dataman/record"
 	"github.com/jacksontj/dataman/stream"
 )
 
-func NewClientStream(ctx context.Context, resultsChan chan stream.Result, errorChan chan error) stream.ClientStream {
+func NewClientStream(ctx context.Context, resultsChan chan record.Record, errorChan chan error) stream.ClientStream {
 	stream := &ClientStream{
 		ctx:         ctx,
 		resultsChan: resultsChan,
@@ -19,7 +20,7 @@ func NewClientStream(ctx context.Context, resultsChan chan stream.Result, errorC
 
 type ClientStream struct {
 	ctx         context.Context
-	resultsChan chan stream.Result
+	resultsChan chan record.Record
 	errorChan   chan error
 }
 
@@ -27,7 +28,7 @@ func (s *ClientStream) Close() error {
 	return nil
 }
 
-func (s *ClientStream) Recv() (stream.Result, error) {
+func (s *ClientStream) Recv() (record.Record, error) {
 	// TODO: implement this cleaner, its a bit of a mess since we want specific
 	// priorities on channel reading
 	for {

--- a/stream/local/server.go
+++ b/stream/local/server.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/jacksontj/dataman/record"
 	"github.com/jacksontj/dataman/stream"
 )
 
 // TODO: context
-func NewServerStream(ctx context.Context, resultsChan chan stream.Result, errorChan chan error) stream.ServerStream {
+func NewServerStream(ctx context.Context, resultsChan chan record.Record, errorChan chan error) stream.ServerStream {
 	sw := &ServerStream{
 		ctx:         ctx,
 		resultsChan: resultsChan,
@@ -24,7 +25,7 @@ func NewServerStream(ctx context.Context, resultsChan chan stream.Result, errorC
 type ServerStream struct {
 	ctx context.Context
 
-	resultsChan chan stream.Result
+	resultsChan chan record.Record
 	errorChan   chan error
 
 	closed    bool
@@ -36,7 +37,7 @@ type ServerStream struct {
 }
 
 // SendResult will send the result r or return an error.
-func (s *ServerStream) SendResult(r stream.Result) error {
+func (s *ServerStream) SendResult(r record.Record) error {
 	s.serverLock.Lock()
 	defer s.serverLock.Unlock()
 	if s.streamErr != nil {

--- a/stream/result.go
+++ b/stream/result.go
@@ -1,10 +1,9 @@
 package stream
 
-// A result that could be sent (currently an empty interface, maybe put marshal methods here)
-type Result interface{}
+import "github.com/jacksontj/dataman/record"
 
 // A chunk of results on the wire
 type ResultChunk struct {
-	Results []Result `json:"results"`
-	Error   string   `json:"error,omitempty"`
+	Results []record.Record `json:"results"`
+	Error   string          `json:"error,omitempty"`
 }

--- a/stream/test.go
+++ b/stream/test.go
@@ -8,18 +8,16 @@ import (
 	"strconv"
 	"testing"
 	"time"
-)
 
-type TestResult struct {
-	Foo string `json:"foo"`
-}
+	"github.com/jacksontj/dataman/record"
+)
 
 // function to create stuff
 func makeStuff(sw ServerStream, itemCount int, errOffset int, sleepStep int) {
 	defer sw.Close()
 	for i := 0; i < itemCount; i++ {
 		time.Sleep(time.Millisecond * time.Duration(sleepStep*i))
-		sw.SendResult(&TestResult{"a"})
+		sw.SendResult(record.Record{"foo": "a"})
 		if errOffset == i {
 			sw.SendError(fmt.Errorf("broken"))
 			return
@@ -27,8 +25,8 @@ func makeStuff(sw ServerStream, itemCount int, errOffset int, sleepStep int) {
 	}
 }
 
-func streamResponses(s ClientStream) ([]Result, error) {
-	results := make([]Result, 0)
+func streamResponses(s ClientStream) ([]record.Record, error) {
+	results := make([]record.Record, 0)
 	for {
 		item, err := s.Recv()
 		if err != nil {


### PR DESCRIPTION
instead of heap allocated reducing allocations and time by ~99%

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkMergeResultStreamsUnique-4     41733870      71448         -99.83%
BenchmarkMergeResultStreams-4           36409736      70792         -99.81%

benchmark                               old allocs     new allocs     delta
BenchmarkMergeResultStreamsUnique-4     84210          236            -99.72%
BenchmarkMergeResultStreams-4           44072          113            -99.74%

benchmark                               old bytes     new bytes     delta
BenchmarkMergeResultStreamsUnique-4     9658043       28734         -99.70%
BenchmarkMergeResultStreams-4           9091594       27201         -99.70%
```