### PR TITLE
Stream perf

### DIFF
--- a/query/result_stream.go
+++ b/query/result_stream.go
@@ -227,7 +227,7 @@ func MergeResultStreamsUnique(ctx context.Context, args QueryArgs, pkeyFields []
 					Record: head.item,
 					Source: i,
 				}
-				heap.Push(h, item)
+				h.PushDirect(item)
 			}
 		}
 
@@ -236,7 +236,7 @@ func MergeResultStreamsUnique(ctx context.Context, args QueryArgs, pkeyFields []
 		resultsSent := uint64(0)
 
 		for h.Len() > 0 {
-			item := heap.Pop(h).(record.RecordItem)
+			item := h.PopDirect()
 
 			// now get the pkey from the item, to ensure no dupes
 			pkeyID := getPkeyID(item.Record)
@@ -270,7 +270,7 @@ func MergeResultStreamsUnique(ctx context.Context, args QueryArgs, pkeyFields []
 					Record: head.item,
 					Source: item.Source,
 				}
-				heap.Push(h, newItem)
+				h.PushDirect(newItem)
 			}
 		}
 	} else {
@@ -383,7 +383,7 @@ func MergeResultStreams(ctx context.Context, args QueryArgs, vshardResults []*Re
 					Record: head.item,
 					Source: i,
 				}
-				heap.Push(h, item)
+				h.PushDirect(item)
 			}
 		}
 
@@ -392,7 +392,7 @@ func MergeResultStreams(ctx context.Context, args QueryArgs, vshardResults []*Re
 		resultsSent := uint64(0)
 
 		for h.Len() > 0 {
-			item := heap.Pop(h).(record.RecordItem)
+			item := h.PopDirect()
 
 			// now get the pkey from the item, to ensure no dupes
 			// If an offset was defined, do that
@@ -421,7 +421,7 @@ func MergeResultStreams(ctx context.Context, args QueryArgs, vshardResults []*Re
 					Record: head.item,
 					Source: item.Source,
 				}
-				heap.Push(h, newItem)
+				h.PushDirect(newItem)
 			}
 		}
 	} else {

--- a/query/result_stream_bench_test.go
+++ b/query/result_stream_bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkResultStreamTransformation(b *testing.B) {
 
 func BenchmarkMergeResultStreamsUnique(b *testing.B) {
 	ctx := context.Background()
-	streams := 3
+	streams := 100
 
 	vals := make([]record.Record, streams)
 
@@ -89,7 +89,7 @@ func BenchmarkMergeResultStreamsUnique(b *testing.B) {
 
 func BenchmarkMergeResultStreams(b *testing.B) {
 	ctx := context.Background()
-	streams := 3
+	streams := 100
 
 	vals := make([]record.Record, streams)
 

--- a/record/heap.go
+++ b/record/heap.go
@@ -1,6 +1,7 @@
 package record
 
 import (
+	"container/heap"
 	"time"
 )
 
@@ -114,5 +115,22 @@ func (r *RecordHeap) Pop() interface{} {
 	n := len(old)
 	x := old[n-1]
 	r.Heap = old[0 : n-1]
+	return x
+}
+
+func (r *RecordHeap) PushDirect(x RecordItem) {
+	r.Heap = append(r.Heap, x)
+	heap.Fix(r, len(r.Heap)-1)
+}
+
+func (r *RecordHeap) PopDirect() RecordItem {
+	n := len(r.Heap) - 1
+	r.Swap(0, n)
+
+	old := r.Heap
+	x := old[n]
+	r.Heap = old[0:n]
+	heap.Fix(r, 0)
+
 	return x
 }


### PR DESCRIPTION
Change the record heap to have `direct` methods which are the exact type, to avoid heap allocations.


```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkResultStream-4                   402831        423458        +5.12%
BenchmarkResultStreamTransformation-4     436764        441225        +1.02%
BenchmarkMergeResultStreamsUnique-4       3174205       3160286       -0.44%
BenchmarkMergeResultStreams-4             2794211       2780949       -0.47%

benchmark                                 old allocs     new allocs     delta
BenchmarkResultStream-4                   10             10             +0.00%
BenchmarkResultStreamTransformation-4     11             11             +0.00%
BenchmarkMergeResultStreamsUnique-4       7439           5438           -26.90%
BenchmarkMergeResultStreams-4             3417           1418           -58.50%

benchmark                                 old bytes     new bytes     delta
BenchmarkResultStream-4                   537           537           +0.00%
BenchmarkResultStreamTransformation-4     545           545           +0.00%
BenchmarkMergeResultStreamsUnique-4       954497        922452        -3.36%
BenchmarkMergeResultStreams-4             901354        869434        -3.54%

```